### PR TITLE
Webpack 2 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function (source) {
         this.cacheable();
     }
 
-    let config = loaderUtils.getLoaderConfig(this, 'semanticUILessLoader');
+    let config = loaderUtils.getOptions(this) || {};
     config.defaultFolder = config.defaultFolder || path.dirname(require.resolve('semantic-ui-less/package.json'));
     config = Object.assign({
         definitionsFolder: path.join(config.defaultFolder, 'definitions'),


### PR DESCRIPTION
Loader configurations [are now passed through an option](https://webpack.js.org/guides/migrating/#loader-configuration-is-through-options):

```javascript
{
  loader: 'semantic-ui-less-loader-custom',
  options: {
    siteFolder: path.join(__dirname, 'src/less/_site')
  }
}
```