### PR TITLE
Make compatible with webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,21 @@ const webpackConfig = {
     context: __dirname,
     entry: './src/semantic.less',
     module: {
-        loaders: [
+        rules: [
             {
                 test: /[.]less$/,
-                loader: 'style-loader!css-loader!semantic-ui-less-loader?sourceMap',
+                use: [
+                    'style-loader',
+                    'css-loader',
+                    {
+                        loader: 'semantic-ui-less-loader',
+                        options: {
+                            siteFolder: path.join(__dirname, 'src/site'),
+                        },
+                    },
+                ],
             },
-         ],
-    },
-    semanticUILessLoader: {
-        siteFolder: path.join(__dirname, 'src/site'),
+        ],
     },
 };
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function (source) {
         this.cacheable();
     }
 
-    let config = loaderUtils.getLoaderConfig(this, 'semanticUILessLoader');
+    let config = loaderUtils.getOptions(this) || {};
     config.defaultFolder = config.defaultFolder || path.dirname(require.resolve('semantic-ui-less/package.json'));
     config = Object.assign({
         definitionsFolder: path.join(config.defaultFolder, 'definitions'),

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "less-loader": "*",
-    "loader-utils": "^0.2.14"
+    "loader-utils": "^1.0.0"
   },
   "devDependencies": {
     "css-loader": "*",

--- a/www/webpack.config.js
+++ b/www/webpack.config.js
@@ -16,16 +16,22 @@ const webpackConfig = {
         filename: 'bundle.js',
     },
     module: {
-        loaders: [
+        rules: [
             {
                 test: /[.]less$/,
-                loader: `style-loader!css-loader!../index.js?sourceMap`,
+                use: [
+                    'style-loader',
+                    'css-loader',
+                    {
+                        loader: '../index.js',
+                        options: {
+                            siteFolder: path.join(__dirname, 'site'),
+                            themeConfigPath:  path.join(__dirname, 'theme.config'),
+                        },
+                    },
+                ],
             },
          ],
-    },
-    semanticUILessLoader: {
-        siteFolder: path.join(__dirname, 'site'),
-        themeConfigPath:  path.join(__dirname, 'theme.config'),
     },
 };
 


### PR DESCRIPTION
This is compatible with the new webpack loader options.

Here the error with current version:
```
For loader options: webpack 2 no longer allows custom properties in configuration.
     Loaders should be updated to allow passing options via loader options in module.rules.
```